### PR TITLE
Fix Stack Corruption with AlterBIOS

### DIFF
--- a/Main.c
+++ b/Main.c
@@ -220,7 +220,7 @@ int main(void)
   G_Attr = (G_attr*)__Get(GLOBAL);
   T_Attr = (T_attr*)__Get(TRIGGER);
 
-  if(memcmp((u8*)__Get(13),"2.81",4)==0)HardwareVersion=1; else HardwareVersion=0;         //HDWVER
+  if(memcmp((u8*)__Get(13),"2.81",4)>=0)HardwareVersion=1; else HardwareVersion=0;         //HDWVER
 
   InitiateCalData();
   LoadBaseBuffers();				

--- a/app1.lds
+++ b/app1.lds
@@ -5,7 +5,13 @@ MEMORY
   rom (rx) : ORIGIN = 0x0800C000, LENGTH = 64K
   spare (rx) : ORIGIN = 0x0802c000, LENGTH = 80K      
   extra (rx) : ORIGIN = 0x08047000, LENGTH = 65K
-  ram (rwx) : ORIGIN = 0x20003000, LENGTH = 64K
+  /* total RAM 64kb, starts from 0x20000000;
+     minus SYS memory 8kb in the beginning
+     (actually less but original APP reserves 8kb);
+     minus possible AlterBIOS memory 5kb in the end
+     (original app reserves everything from 0x2000abe0);
+     total = 51kb */
+  ram (rwx) : ORIGIN = 0x20002000, LENGTH = 51K
 }
 
 INCLUDE main.lds

--- a/main.lds
+++ b/main.lds
@@ -1,4 +1,5 @@
-_estack = ORIGIN(ram)+LENGTH(ram)-0x4000;
+/* stack pointer should point to the address ABOVE the available RAM */
+_estack = ORIGIN(ram)+LENGTH(ram);
 /*_estack = ORIGIN(ram)+LENGTH(ram)-0x2000;*/
 
 /* Linker script for Olimex STM32-H103 eval board.


### PR DESCRIPTION
AlterBIOS stores its data in the upper 5k of the RAM.
And we originally had our stack bottom on 0x20003000 + 64K - 0x4000 = 0x2000f000,
thus intersecting with AlterBIOS.
As a result, installed and enabled (via patch) AlterBIOS caused the firmware to hang during boot.

AlterBIOS does fix FAT corruption which is IMO important.
This PR aims to fix that issue by properly redefining memory addresses.